### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/digitalHuman/utils/configParser.py
+++ b/digitalHuman/utils/configParser.py
@@ -9,7 +9,7 @@ from digitalHuman.utils.env import CONFIG_ROOT_PATH, CONFIG_FILE
 from yacs.config import CfgNode as CN
 
 def parseConfig(configFile: str) -> CN:
-    with open(configFile, 'r') as f:
+    with open(configFile, 'r', encoding='utf-8') as f:
         config = CN.load_cfg(f)
         return config
     


### PR DESCRIPTION
Fix UnicodeDecodeError (show on the Windows system):
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaf in position 6: illegal multibyte sequence