### PR TITLE
:feat: support ali nls emotion tts

### DIFF
--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -13,7 +13,7 @@ SERVER:
       SUPPORT_LIST: [ "openaiAPI.yaml", "baiduAPI.yaml" ]
       DEFAULT: "openaiAPI.yaml"
     TTS: 
-      SUPPORT_LIST: [ "edgeAPI.yaml", "baiduAPI.yaml", "difyAPI.yaml" ]
+      SUPPORT_LIST: [ "edgeAPI.yaml", "baiduAPI.yaml", "difyAPI.yaml", "aliNLS.yaml" ]
       DEFAULT: "edgeAPI.yaml"
   AGENTS: 
     SUPPORT_LIST: [ "repeaterAgent.yaml", "difyAgent.yaml", "fastgptAgent.yaml", "openaiAgent.yaml" ]

--- a/configs/engines/tts/aliNLS.yaml
+++ b/configs/engines/tts/aliNLS.yaml
@@ -1,0 +1,10 @@
+NAME: "AliNLSTTS" # Name of the engine, will be used for registration
+URL: "wss://nls-gateway-cn-shanghai.aliyuncs.com/ws/v1" # Default NLS Gateway URL, can change to other region
+TOKEN: "YOUR_TOKEN"   # Replace with your actual Token (consider security implications and if it needs dynamic fetching), get token from https://help.aliyun.com/zh/isi/getting-started/obtain-an-access-token-1/
+APPKEY: "YOUR_APPKEY"  # get app key: https://nls-portal.console.aliyun.com/applist
+VOICE: "zhimi_emo"        # Default voice, many others are available e.g. siqi, xiaoyao for emotions
+FORMAT: "wav"         # Output audio format (mp3, wav). NLS SDK default is pcm, we change to `wav`.
+SAMPLE_RATE: 16000    # Audio sample rate. NLS SDK default is 16000 for pcm.
+# Add other parameters as needed, e.g. speech_rate, pitch_rate, volume
+# For emotions, the SSML will carry the tags, but specific voices might be better.
+# Example SSML: <speak><emotion category="happy" intensity="1.0">今天天气真好</emotion></speak>

--- a/digitalHuman/engine/tts/__init__.py
+++ b/digitalHuman/engine/tts/__init__.py
@@ -7,6 +7,7 @@
 from .baiduTTS import BaiduAPI
 from .edgeTTS import EdgeAPI
 from .difyTTS import DifyAPI
+from .aliNLSTTS import AliNLSTTS
 from .ttsFactory import TTSFactory
 
 __all__ = ['TTSFactory']

--- a/digitalHuman/engine/tts/aliNLSTTS.py
+++ b/digitalHuman/engine/tts/aliNLSTTS.py
@@ -1,0 +1,137 @@
+import asyncio
+import random
+import threading
+from io import BytesIO
+from typing import Optional # Added for type hinting
+
+import nls # Alibaba NLS SDK, when need to be installed
+
+from ..builder import TTSEngines
+from ..engineBase import BaseEngine
+from digitalHuman.utils import logger, TextMessage, AudioMessage, AudioFormatType
+from yacs.config import CfgNode as CN
+
+__all__ = ["AliNLSTTS"]
+
+@TTSEngines.register("AliNLSTTS")
+class AliNLSTTS(BaseEngine):
+    EMOTION_VOICE_SET = {"zhifeng_emo", "zhibing_emo", "zhitian_emo", "zhibei_emo", "zhiyan_emo", "zhimi_emo", "zhimiao_emo"}
+    EMOTION_LIST = ['angry', 'fear', 'happy', 'hate', 'neutral', 'sad', 'surprise']
+
+    def checkKeys(self):
+        return ["URL", "TOKEN", "VOICE", "FORMAT", "SAMPLE_RATE"]
+
+    def voice_check(self, voice: str) -> None:
+        if voice not in self.EMOTION_VOICE_SET:
+            raise ValueError(f"Invalid voice: {voice}. Available voices: {self.EMOTION_VOICE_SET}")
+
+    def generate_remotion_ssml_text(self, text: str) -> str:
+        return f'<speak><emotion category="{random.choice(self.EMOTION_LIST)}" intensity="1.0">{text}</emotion></speak>'
+
+    def setup(self):
+        logger.info(f"[{self.cfg.NAME}] Engine setup.")
+
+        # Optional: Initialize any shared resources or configurations here
+        # The NLS SDK's SpeechSynthesizer is typically created per request as in the example
+
+    class NlsWorker:
+        def __init__(self, text: str, config: CN):
+            self._text = text
+            self._config = config
+            self._audio_buffer = BytesIO()
+            self._completion_event = threading.Event()
+            self._error_occurred = False
+            self._error_message = ""
+
+            # Configure NLS SDK debugging based on environment or config
+            # nls.enableTrace(True) # Enable for debugging if needed
+
+        def on_error(self, message, *args):
+            logger.error(f"[{self._config.NAME}] On error: {message}, args: {args}")
+            self._error_message = str(message)
+            self._error_occurred = True
+            self._completion_event.set() # Signal completion even on error
+
+        def on_close(self, *args):
+            logger.debug(f"[{self._config.NAME}] On close: args: {args}")
+            self._completion_event.set() # Ensure completion is signaled
+
+        def on_data(self, data, *args):
+            if data:
+                self._audio_buffer.write(data)
+
+        def on_completed(self, message, *args):
+            logger.debug(f"[{self._config.NAME}] On completed: {message}")
+            self._completion_event.set()
+
+        def synthesize(self) -> Optional[bytes]:
+            tts = nls.NlsSpeechSynthesizer(
+                url=self._config.URL,
+                appkey=self._config.APPKEY,
+                token=self._config.TOKEN,
+                on_data=self.on_data,
+                on_completed=self.on_completed,
+                on_error=self.on_error,
+                on_close=self.on_close,
+                callback_args=[] 
+            )
+
+            logger.debug(f"[{self._config.NAME}] Starting TTS synthesis for text: {self._text[:50]}...")
+            # The NLS SDK's start method expects parameters like voice, format, sample_rate.
+            # Make sure these are correctly passed from the config.
+            # The text input here is expected to be SSML.
+            logger.info(f"{self._text=}")
+            tts.start(
+                self._text,
+                voice=self._config.VOICE,
+                aformat=self._config.FORMAT.lower(), # SDK expects 'pcm', 'mp3', 'wav'
+                sample_rate=self._config.SAMPLE_RATE
+            )
+
+            self._completion_event.wait() # Wait for callbacks to complete
+
+            if self._error_occurred:
+                logger.error(f"[{self._config.NAME}] Synthesis failed: {self._error_message}")
+                return None
+            
+            self._audio_buffer.seek(0)
+            return self._audio_buffer.getvalue()
+
+    async def run(self, input: TextMessage, **kwargs) -> Optional[AudioMessage]:
+        logger.info(f"[{self.cfg.NAME}] Received text for TTS: {input.data[:50]}...")
+        self.voice_check(self.cfg.VOICE)
+        if not input.data:
+            logger.warning(f"[{self.cfg.NAME}] Received empty text for TTS.")
+            return None
+
+        try:
+            worker = self.NlsWorker(text=self.generate_remotion_ssml_text(input.data), config=self.cfg)
+            # change to async function
+            loop = asyncio.get_event_loop()
+
+            audio_content = await loop.run_in_executor(None, worker.synthesize)
+            config_audio_out_format = self.cfg.FORMAT.lower()
+            if audio_content:
+                if config_audio_out_format == "mp3":
+                    audio_format = AudioFormatType.MP3
+                elif config_audio_out_format == "wav":
+                    audio_format = AudioFormatType.WAV
+                else:
+                    raise ValueError(f"Unsupported {config_audio_out_format} for ALI NLS tts")
+                
+                logger.info(f"[{self.cfg.NAME}] TTS synthesis successful. Audio size: {len(audio_content)} bytes")
+                return AudioMessage(
+                    data=audio_content,
+                    format=audio_format,
+                    sampleRate=self.cfg.SAMPLE_RATE,
+                    sampleWidth=0, # This might need adjustment based on format
+                    desc="Alibaba NLS TTS"
+                )
+            else:
+                logger.error(f"[{self.cfg.NAME}] TTS synthesis failed to produce audio content.")
+                return None
+
+        except Exception as e:
+            logger.error(f"[{self.cfg.NAME}] Engine run failed: {e}", exc_info=True)
+            return None
+

--- a/docker/adhServer.Dockerfile
+++ b/docker/adhServer.Dockerfile
@@ -17,7 +17,7 @@ RUN rm /var/lib/apt/lists/* -vf
 
 # apt安装依赖库
 RUN apt update \
-  && apt-get install -y git g++ vim python3-pip ffmpeg\
+  && apt-get install -y git g++ vim python3-pip ffmpeg flac\
   && rm -rf /var/lib/apt/lists/*
 
 # pip设置修改

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ SpeechRecognition==3.10.1
 requests==2.31.0
 uvicorn==0.26.0
 yacs==0.1.8
+git+https://github.com/aliyun/alibabacloud-nls-python-sdk.git@main#egg=alibabacloud-nls-python-sdk

--- a/test/test_ali_nls_tts.py
+++ b/test/test_ali_nls_tts.py
@@ -1,0 +1,75 @@
+import asyncio
+import os
+import pytest
+
+from digitalHuman.utils.configParser import config
+from digitalHuman.engine.tts.ttsFactory import TTSFactory
+from digitalHuman.utils.protocol import TextMessage, AudioMessage
+from digitalHuman.utils import logger
+
+# 配置日志
+@pytest.fixture(scope="module")
+def setup_logger():
+    logger.getLogger().setLevel(logger.DEBUG)
+    handler = logger.StreamHandler()
+    handler.setFormatter(logger.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    logger.getLogger().addHandler(handler)
+
+# 加载配置文件路径
+@pytest.fixture(scope="module")
+def tts_config_file():
+    config_dir = "configs"
+    tts_config_file = os.path.join(config_dir, "engines", "tts", "aliNLS.yaml")
+    if not os.path.exists(tts_config_file):
+        pytest.fail(f"TTS config file not found: {tts_config_file}")
+    return tts_config_file
+
+# 创建 TTS 引擎
+@pytest.fixture(scope="module")
+def event_loop():
+    loop = asyncio.get_event_loop()
+    yield loop
+    loop.close()
+
+@pytest.fixture(scope="module")
+async def tts_engine(tts_config_file):
+    try:
+        for cn in config.SERVER.ENGINES.TTS.SUPPORT_LIST:
+            if cn.NAME == "AliNLSTTS":
+                tts_engine_cfg_node = cn
+                break
+        else:
+            pytest.fail("No TTS engine found in config file.")
+
+        if "YOUR_APPKEY" in tts_engine_cfg_node.APPKEY or "YOUR_TOKEN" in tts_engine_cfg_node.TOKEN:
+            pytest.skip("Placeholder APPKEY or TOKEN found in aliNLS.yaml. Please update with real credentials.")
+
+        engine = TTSFactory.create(tts_engine_cfg_node)
+        logger.info(f"Successfully created TTS engine: {engine.name}")
+        return engine
+    except Exception as e:
+        pytest.fail(f"Error creating TTS engine: {e}")
+# 实际测试逻辑
+@pytest.mark.asyncio
+async def test_ali_nls_tts(tts_engine):
+    ssml_text = '<speak><emotion category="happy" intensity="1.0">今天天气真好，阳光明媚！</emotion></speak>'
+    output_filename = "test_output_happy.pcm"
+
+    text_message = TextMessage(data=ssml_text)
+
+    try:
+        audio_message: AudioMessage = await tts_engine.run(text_message)
+
+        assert audio_message is not None, "TTS 返回为空"
+        assert audio_message.data is not None and len(audio_message.data) > 0, "音频数据为空"
+
+        os.makedirs("outputs", exist_ok=True)
+        output_path = os.path.join("outputs", output_filename)
+        with open(output_path, "wb") as f:
+            f.write(audio_message.data)
+
+        logger.info(f"音频保存成功: {output_path}")
+        logger.info(f"音频格式: {audio_message.format}, 采样率: {audio_message.sampleRate}")
+
+    except Exception as e:
+        pytest.fail(f"TTS 合成过程中发生错误: {e}")


### PR DESCRIPTION
### Support emotion TTS

I've added a new TTS engine, AliNLSTTS, to support Text-to-Speech
synthesis using Alibaba Cloud's NLS service.

Key changes:
- I added `AliNLSTTS` engine implementation in `digitalHuman/engine/tts/aliNLSTTS.py`,
  which utilizes the `nls` Python SDK.
- I introduced `configs/engines/tts/aliNLS.yaml` for engine-specific
  configuration (URL, AppKey, Token, Voice, Format, Sample Rate).
  You must provide your own AppKey and Token.
- I updated `configs/config_template.yaml` to include `aliNLS.yaml` in the
  list of supported TTS engines and set it as the default for now.
- I added `nls` to `requirements.txt` as a dependency.
- The engine expects SSML input (e.g., from an LLM) to enable
  emotion synthesis. For example:
  `<speak><emotion category="happy">你好</emotion></speak>`
- I included a test script `test/test_ali_nls_tts.py` for direct
  engine testing. You need to configure your credentials before running.

This integration allows for more expressive speech output by leveraging
Alibaba NLS's emotion TTS capabilities.